### PR TITLE
Locale

### DIFF
--- a/common/handlers/handlers.yml
+++ b/common/handlers/handlers.yml
@@ -35,3 +35,12 @@
   action: service name=mdm state=restarted
   become: yes
 
+# LOCALES
+- name: rebuild locales
+  command: /usr/sbin/locale-gen
+  become: yes
+
+# handlers file for locale.gen
+- name: generate locales
+  command: locale-gen
+  become: yes

--- a/common/tasks/locale.yml
+++ b/common/tasks/locale.yml
@@ -43,16 +43,7 @@
     line: "{{ item.line }}"
     state: "{{ item.state }}"
   with_items:
-    # - { regexp: '^#? ?de_DE ISO-8859-1', line: 'de_DE ISO-8859-1', state: present }
-    # - { regexp: '^#? ?de_DE.UTF-8 UTF-8', line: 'de_DE.UTF-8 UTF-8', state: present }
-    # - { regexp: '^#? ?de_DE@euro ISO-8859-15', line: 'de_DE@euro ISO-8859-15', state: present }
-    # - { regexp: '^#? ?en_GB ISO-8859-1', line: 'en_GB ISO-8859-1', state: present }
-    # - { regexp: '^#? ?en_GB.ISO-8859-15 ISO-8859-15', line: 'en_GB.ISO-8859-15 ISO-8859-15', state: present }
-    # - { regexp: '^#? ?en_GB.UTF-8 UTF-8', line: 'en_GB.UTF-8 UTF-8', state: present }
-    # - { regexp: '^#? ?en_US ISO-8859-1', line: 'en_US ISO-8859-1', state: present }
-    # - { regexp: '^#? ?en_US.ISO-8859-15 ISO-8859-15', line: 'en_US.ISO-8859-15 ISO-8859-15', state: present }
-    # - { regexp: '^#? ?en_US.UTF-8 UTF-8', line: 'en_US.UTF-8 UTF-8', state: present }
-    - { regexp: '^#? ?en_AU.UTF-8 UTF-8', line: 'en_AU.UTF-8 UTF-8', state: present }
+    - { regexp: "^#? ?{{ locale }} UTF-8", line: "{{ locale }} UTF-8", state: present }
   when: ansible_os_family == "Debian"
   notify: generate locales
   

--- a/common/tasks/locale.yml
+++ b/common/tasks/locale.yml
@@ -3,33 +3,22 @@
 # Configure System Locale
 #
 
-- name: Setup System Locale as EN_AU.UTF-8
+- name: Setup locale in zsh
   lineinfile:
     dest: "/home/{{ ansible_ssh_user }}/.zshenv"
     state: present
     line: "{{ item.line }}"
   with_items:
-    - { line: "export LANGUAGE=en_AU.UTF-8" }
-    - { line: "export LC_ALL=en_AU.UTF-8" }
-    - { line: "export LANG=en_AU.UTF-8" }
-    - { line: "export LC_TYPE=en_AU.UTF-8" }
- # command: /usr/sbin/update-locale LANG="en_AU.UTF-8" LC_ALL="en_AU.UTF-8"
-# - name: Setup System Locale as EN_AU.UTF-8
-#   lineinfile:
-#     dest: "/home/{{ ansible_ssh_user }}/.zshenv"
-#     state: present
-#     line: "{{ item.line }}"
-#   with_items:
-#     - { line: "export LANGUAGE=en_AU.UTF-8" }
-#     - { line: "export LC_ALL=en_AU.UTF-8" }
-#     - { line: "export LANG=en_AU.UTF-8" }
-#     - { line: "export LC_TYPE=en_AU.UTF-8" }
+    - { line: "export LANGUAGE={{ locale }}" }
+    - { line: "export LC_ALL={{ locale }}" }
+    - { line: "export LANG={{ locale }}" }
+    - { line: "export LC_TYPE={{ locale }}" }
 
 - name: prepare locale info
   command: "{{ item }}"
   with_items:
-    - echo locales locales/locales_to_be_generated multiselect     de_DE ISO-8859-1, de_DE.UTF-8 UTF-8, de_DE@euro ISO-8859-15, en_GB ISO-8859-1, en_GB.ISO-8859-15 ISO-8859-15, en_GB.UTF-8 UTF-8, en_US ISO-8859-1, en_US.ISO-8859-15 ISO-8859-15, en_US.UTF-8 UTF-8 en_AU.UTF-8 UTF-8 | debconf-set-selections
-    - echo locales locales/default_environment_locale      select  en_AU.UTF-8 | debconf-set-selections
+    - "echo locales locales/locales_to_be_generated multiselect {{ locale }} | debconf-set-selections"
+    - "echo locales locales/default_environment_locale      select {{ locale }} | debconf-set-selections"
     - dpkg-reconfigure locales -f noninteractive
     - touch /root/.locales-updated
   when: ansible_distribution == 'Debian'

--- a/common/tasks/locale.yml
+++ b/common/tasks/locale.yml
@@ -14,3 +14,59 @@
     - { line: "export LANG=en_AU.UTF-8" }
     - { line: "export LC_TYPE=en_AU.UTF-8" }
  # command: /usr/sbin/update-locale LANG="en_AU.UTF-8" LC_ALL="en_AU.UTF-8"
+# - name: Setup System Locale as EN_AU.UTF-8
+#   lineinfile:
+#     dest: "/home/{{ ansible_ssh_user }}/.zshenv"
+#     state: present
+#     line: "{{ item.line }}"
+#   with_items:
+#     - { line: "export LANGUAGE=en_AU.UTF-8" }
+#     - { line: "export LC_ALL=en_AU.UTF-8" }
+#     - { line: "export LANG=en_AU.UTF-8" }
+#     - { line: "export LC_TYPE=en_AU.UTF-8" }
+
+- name: prepare locale info
+  command: "{{ item }}"
+  with_items:
+    - echo locales locales/locales_to_be_generated multiselect     de_DE ISO-8859-1, de_DE.UTF-8 UTF-8, de_DE@euro ISO-8859-15, en_GB ISO-8859-1, en_GB.ISO-8859-15 ISO-8859-15, en_GB.UTF-8 UTF-8, en_US ISO-8859-1, en_US.ISO-8859-15 ISO-8859-15, en_US.UTF-8 UTF-8 en_AU.UTF-8 UTF-8 | debconf-set-selections
+    - echo locales locales/default_environment_locale      select  en_AU.UTF-8 | debconf-set-selections
+    - dpkg-reconfigure locales -f noninteractive
+    - touch /root/.locales-updated
+  when: ansible_distribution == 'Debian'
+  args:
+    creates: /root/.locales-updated
+
+- name: set locales
+  lineinfile:
+    dest: /etc/locale.gen
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
+    state: "{{ item.state }}"
+  with_items:
+    # - { regexp: '^#? ?de_DE ISO-8859-1', line: 'de_DE ISO-8859-1', state: present }
+    # - { regexp: '^#? ?de_DE.UTF-8 UTF-8', line: 'de_DE.UTF-8 UTF-8', state: present }
+    # - { regexp: '^#? ?de_DE@euro ISO-8859-15', line: 'de_DE@euro ISO-8859-15', state: present }
+    # - { regexp: '^#? ?en_GB ISO-8859-1', line: 'en_GB ISO-8859-1', state: present }
+    # - { regexp: '^#? ?en_GB.ISO-8859-15 ISO-8859-15', line: 'en_GB.ISO-8859-15 ISO-8859-15', state: present }
+    # - { regexp: '^#? ?en_GB.UTF-8 UTF-8', line: 'en_GB.UTF-8 UTF-8', state: present }
+    # - { regexp: '^#? ?en_US ISO-8859-1', line: 'en_US ISO-8859-1', state: present }
+    # - { regexp: '^#? ?en_US.ISO-8859-15 ISO-8859-15', line: 'en_US.ISO-8859-15 ISO-8859-15', state: present }
+    # - { regexp: '^#? ?en_US.UTF-8 UTF-8', line: 'en_US.UTF-8 UTF-8', state: present }
+    - { regexp: '^#? ?en_AU.UTF-8 UTF-8', line: 'en_AU.UTF-8 UTF-8', state: present }
+  when: ansible_os_family == "Debian"
+  notify: generate locales
+  
+# Undesirable as it overrides the locale.gen file and we loose other locales
+# tasks file for locale 
+# - name: set locale-gen file
+#   template: src=locale-gen.j2 dest=/etc/locale.gen
+#   when: ansible_os_family == "Debian"
+#   notify: generate locales
+
+- name: set locale
+  become: yes
+  template:
+    src: common/templates/default-locale.j2
+    dest: /etc/default/locale
+  when: ansible_os_family == "Debian"
+  notify: rebuild locales

--- a/common/tasks/locale.yml
+++ b/common/tasks/locale.yml
@@ -1,0 +1,7 @@
+---
+#
+# Configure System Locale
+#
+
+- name: Setup System Locale as EN_US.UTF-8
+  command: /usr/sbin/update-locale LANG="en_US.UTF-8" LC_ALL="en_US.UTF-8"

--- a/common/tasks/locale.yml
+++ b/common/tasks/locale.yml
@@ -9,16 +9,16 @@
     state: present
     line: "{{ item.line }}"
   with_items:
-    - { line: "export LANGUAGE={{ locale }}" }
-    - { line: "export LC_ALL={{ locale }}" }
-    - { line: "export LANG={{ locale }}" }
-    - { line: "export LC_TYPE={{ locale }}" }
+    - { line: "export LANGUAGE={{ locale.locale }}" }
+    - { line: "export LC_ALL={{ locale.locale }}" }
+    - { line: "export LANG={{ locale.locale }}" }
+    - { line: "export LC_TYPE={{ locale.locale }}" }
 
-- name: prepare locale info
+- name: prepare locales info
   command: "{{ item }}"
   with_items:
-    - "echo locales locales/locales_to_be_generated multiselect {{ locale }} | debconf-set-selections"
-    - "echo locales locales/default_environment_locale      select {{ locale }} | debconf-set-selections"
+    - "echo locales locales/locales_to_be_generated multiselect {{ locale.locale }} | debconf-set-selections"
+    - "echo locales locales/default_environment_locale      select {{ locale.locale }} | debconf-set-selections"
     - dpkg-reconfigure locales -f noninteractive
     - touch /root/.locales-updated
   when: ansible_distribution == 'Debian'
@@ -32,7 +32,7 @@
     line: "{{ item.line }}"
     state: "{{ item.state }}"
   with_items:
-    - { regexp: "^#? ?{{ locale }} UTF-8", line: "{{ locale }} UTF-8", state: present }
+    - { regexp: "^#? ?{{ locale.locale }} UTF-8", line: "{{ locale.locale }} UTF-8", state: present }
   when: ansible_os_family == "Debian"
   notify: generate locales
   

--- a/common/tasks/locale.yml
+++ b/common/tasks/locale.yml
@@ -3,5 +3,14 @@
 # Configure System Locale
 #
 
-- name: Setup System Locale as EN_US.UTF-8
-  command: /usr/sbin/update-locale LANG="en_US.UTF-8" LC_ALL="en_US.UTF-8"
+- name: Setup System Locale as EN_AU.UTF-8
+  lineinfile:
+    dest: "/home/{{ ansible_ssh_user }}/.zshenv"
+    state: present
+    line: "{{ item.line }}"
+  with_items:
+    - { line: "export LANGUAGE=en_AU.UTF-8" }
+    - { line: "export LC_ALL=en_AU.UTF-8" }
+    - { line: "export LANG=en_AU.UTF-8" }
+    - { line: "export LC_TYPE=en_AU.UTF-8" }
+ # command: /usr/sbin/update-locale LANG="en_AU.UTF-8" LC_ALL="en_AU.UTF-8"

--- a/common/templates/default-locale.j2
+++ b/common/templates/default-locale.j2
@@ -1,35 +1,35 @@
 # {{ ansible_managed }}
-LANG="{{ locale | default(locale) }}"
-{% if locale_all is defined %}
-LC_ALL="{{ locale_all }}"
+LANG="{{ locale.locale | default(locale) }}"
+{% if locale.locale_all is defined %}
+LC_ALL="{{ locale.locale_all }}"
 {% endif %}
-{% if locale_language | default(locale_language) is defined %}
-LANGUAGE="{{ locale_language | default(locale_language) }}"
+{% if locale.language | default(locale_language) is defined %}
+LANGUAGE="{{ locale.language | default(locale_language) }}"
 {% endif %}
-{% if locale_numeric | default(locale_numeric) is defined %}
-LC_NUMERIC="{{ locale_numeric | default(locale_numeric) }}"
+{% if locale.numeric | default(locale_numeric) is defined %}
+LC_NUMERIC="{{ locale.numeric | default(locale_numeric) }}"
 {% endif %}
-{% if locale_time | default(locale_time) is defined %}
-LC_TIME="{{ locale_time | default(locale_time) }}"
+{% if locale.time | default(locale_time) is defined %}
+LC_TIME="{{ locale.time | default(locale_time) }}"
 {% endif %}
-{% if locale_monetary | default(locale_monetary) is defined %}
-LC_MONETARY="{{ locale_monetary | default(locale_monetary) }}"
+{% if locale.monetary | default(locale_monetary) is defined %}
+LC_MONETARY="{{ locale.monetary | default(locale_monetary) }}"
 {% endif %}
-{% if locale_paper | default(locale_paper) is defined %}
-LC_PAPER="{{ locale_paper | default(locale_paper) }}"
+{% if locale.paper | default(locale_paper) is defined %}
+LC_PAPER="{{ locale.paper | default(locale_paper) }}"
 {% endif %}
-{% if locale_identification | default(locale_identification) is defined %}
-LC_IDENTIFICATION="{{ locale_identification | default(locale_identification) }}"
+{% if locale.identification | default(locale_identification) is defined %}
+LC_IDENTIFICATION="{{ locale.identification | default(locale_identification) }}"
 {% endif %}
-{% if locale_name | default(locale_name) is defined %}
-LC_NAME="{{ locale_name | default(locale_name) }}"
+{% if locale.name | default(locale_name) is defined %}
+LC_NAME="{{ locale.name | default(locale_name) }}"
 {% endif %}
-{% if locale_address | default(locale_address) is defined %}
-LC_ADDRESS="{{ locale_address | default(locale_address) }}"
+{% if locale.address | default(locale_address) is defined %}
+LC_ADDRESS="{{ locale.address | default(locale_address) }}"
 {% endif %}
-{% if locale_telephone | default(locale_telephone) is defined %}
-LC_TELEPHONE="{{ locale_telephone | default(locale_telephone) }}"
+{% if locale.telephone | default(locale_telephone) is defined %}
+LC_TELEPHONE="{{ locale.telephone | default(locale_telephone) }}"
 {% endif %}
-{% if locale_measurement | default(locale_measurement) is defined %}
-LC_MEASUREMENT="{{ locale_measurement | default(locale_measurement) }}"
+{% if locale.measurement | default(locale_measurement) is defined %}
+LC_MEASUREMENT="{{ locale.measurement | default(locale_measurement) }}"
 {% endif %}

--- a/common/templates/default-locale.j2
+++ b/common/templates/default-locale.j2
@@ -1,0 +1,35 @@
+# {{ ansible_managed }}
+LANG="{{ locale | default(locale) }}"
+{% if locale_all is defined %}
+LC_ALL="{{ locale_all }}"
+{% endif %}
+{% if locale_language | default(locale_language) is defined %}
+LANGUAGE="{{ locale_language | default(locale_language) }}"
+{% endif %}
+{% if locale_numeric | default(locale_numeric) is defined %}
+LC_NUMERIC="{{ locale_numeric | default(locale_numeric) }}"
+{% endif %}
+{% if locale_time | default(locale_time) is defined %}
+LC_TIME="{{ locale_time | default(locale_time) }}"
+{% endif %}
+{% if locale_monetary | default(locale_monetary) is defined %}
+LC_MONETARY="{{ locale_monetary | default(locale_monetary) }}"
+{% endif %}
+{% if locale_paper | default(locale_paper) is defined %}
+LC_PAPER="{{ locale_paper | default(locale_paper) }}"
+{% endif %}
+{% if locale_identification | default(locale_identification) is defined %}
+LC_IDENTIFICATION="{{ locale_identification | default(locale_identification) }}"
+{% endif %}
+{% if locale_name | default(locale_name) is defined %}
+LC_NAME="{{ locale_name | default(locale_name) }}"
+{% endif %}
+{% if locale_address | default(locale_address) is defined %}
+LC_ADDRESS="{{ locale_address | default(locale_address) }}"
+{% endif %}
+{% if locale_telephone | default(locale_telephone) is defined %}
+LC_TELEPHONE="{{ locale_telephone | default(locale_telephone) }}"
+{% endif %}
+{% if locale_measurement | default(locale_measurement) is defined %}
+LC_MEASUREMENT="{{ locale_measurement | default(locale_measurement) }}"
+{% endif %}

--- a/common/templates/locale-gen.j2
+++ b/common/templates/locale-gen.j2
@@ -1,0 +1,8 @@
+# Ansible managed file -- do not edit
+# This file lists locales that you wish to have built. You can find a list
+# of valid supported locales at /usr/share/i18n/SUPPORTED, and you can add
+# user defined locales to /usr/local/share/i18n/SUPPORTED. If you change
+# this file, you need to rerun locale-gen.
+
+{{ locale }}
+

--- a/locale.yml
+++ b/locale.yml
@@ -1,0 +1,7 @@
+---
+#
+# Configure System Locale
+#
+
+- name: Setup System Locale as EN_US.UTF-8
+  command: /usr/sbin/update-locale LANG="en_US.UTF-8" LC_ALL="en_US.UTF-8"

--- a/locale.yml
+++ b/locale.yml
@@ -1,7 +1,0 @@
----
-#
-# Configure System Locale
-#
-
-- name: Setup System Locale as EN_US.UTF-8
-  command: /usr/sbin/update-locale LANG="en_US.UTF-8" LC_ALL="en_US.UTF-8"

--- a/vars/defaults.yml
+++ b/vars/defaults.yml
@@ -15,16 +15,16 @@ xbmc_spotify: 'http://azkotoki.org/download-file/28/script-audio-spotimc-1-0-bet
 ###
 # Locale
 ###
-# locale_all: "en_AU.UTF-8 UTF-8" # should only be used for testing
+# locale_all: "en_AU.UTF-8" # should only be used for testing
 # locale: "en_AU.UTF-8"
 locale_language: "en_AU:en"
-locale_numeric: "en_AU.UTF-8 UTF-8"
-locale_time: "en_AU.UTF-8 UTF-8"
-locale_monetary: "en_AU.UTF-8 UTF-8"
-locale_paper: "en_AU.UTF-8 UTF-8"
-locale_identification: "en_AU.UTF-8 UTF-8"
-locale_name: "en_AU.UTF-8 UTF-8"
-locale_address: "en_AU.UTF-8 UTF-8"
-locale_telephone: "en_AU.UTF-8 UTF-8"
-locale_measurement: "en_AU.UTF-8 UTF-8"
+locale_numeric: "en_AU.UTF-8"
+locale_time: "en_AU.UTF-8"
+locale_monetary: "en_AU.UTF-8"
+locale_paper: "en_AU.UTF-8"
+locale_identification: "en_AU.UTF-8"
+locale_name: "en_AU.UTF-8"
+locale_address: "en_AU.UTF-8"
+locale_telephone: "en_AU.UTF-8"
+locale_measurement: "en_AU.UTF-8"
 

--- a/vars/defaults.yml
+++ b/vars/defaults.yml
@@ -2,7 +2,7 @@
 #
 # Override these settings in custom.yml
 #
-locale: "en_AU.UTF-8"
+
 jvm_folder: "/opt"
 gems_version: "2.1.0"
 ruby_version: "2.1.4"
@@ -11,3 +11,20 @@ db_user: 'vps'       # This should be the same as your user
 db_passwd: 'secret'  # Change this to something more secure
 custom_ntp_server: ''
 xbmc_spotify: 'http://azkotoki.org/download-file/28/script-audio-spotimc-1-0-beta5'
+
+###
+# Locale
+###
+# locale_all: "en_AU.UTF-8 UTF-8" # should only be used for testing
+# locale: "en_AU.UTF-8"
+locale_language: "en_AU:en"
+locale_numeric: "en_AU.UTF-8 UTF-8"
+locale_time: "en_AU.UTF-8 UTF-8"
+locale_monetary: "en_AU.UTF-8 UTF-8"
+locale_paper: "en_AU.UTF-8 UTF-8"
+locale_identification: "en_AU.UTF-8 UTF-8"
+locale_name: "en_AU.UTF-8 UTF-8"
+locale_address: "en_AU.UTF-8 UTF-8"
+locale_telephone: "en_AU.UTF-8 UTF-8"
+locale_measurement: "en_AU.UTF-8 UTF-8"
+


### PR DESCRIPTION
-Create new locale.yml
-Set default locale to be en-AU
-Allow user to override locale and specify units (eg. measurement can be set to a different locale)
-Use regex to uncomment desired locale in locale.gen
-Runs local-gen to set locales